### PR TITLE
fix _init_sasl for gcc version 4.1.2

### DIFF
--- a/pgmemcache.h
+++ b/pgmemcache.h
@@ -60,7 +60,7 @@ static void *pgmemcache_malloc(memcached_st *ptr __attribute__((unused)), const 
 static void pgmemcache_free(memcached_st *ptr __attribute__((unused)), void *mem, void *context);
 static void *pgmemcache_realloc(memcached_st *ptr __attribute__((unused)), void *, const size_t, void *context);
 static void *pgmemcache_calloc(memcached_st *ptr __attribute__((unused)), size_t nelem, const size_t, void *context);
-int _init_sasl(void) ;
+static int _init_sasl(void);
 
 #define PG_MEMCACHE_ADD                 0x0001
 #define PG_MEMCACHE_REPLACE             0x0002


### PR DESCRIPTION
static declaration follows non-static declaration
